### PR TITLE
JNT-281 get port API does not return VIF type

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin.py
@@ -442,6 +442,8 @@ class NeutronPluginContrailCoreV2(neutron_plugin_base_v2.NeutronPluginBaseV2,
         return port_res
 
     def _make_port_dict(self, port):
+        if port:
+            port['binding:vif_type'] = portbindings.VIF_TYPE_VROUTER
         return port
 
     def _get_port(self, context, id, fields=None):


### PR DESCRIPTION
This patch fill binding:vif_type field.

Closes-Bhug: JNT-281
